### PR TITLE
Add code reformatter and minor fixes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,16 @@ function App() {
         setLogs(logger.logs());
     }
 
+    const lineFormat = (line:string) : string => {
+        line = line.trim().toUpperCase();
+        const label = line.match(/^[A-Z][0-9A-Z]{0,2},/);
+        
+        if(label === null)
+            return "    " + line;
+        
+        return label.toString() + " ".repeat(4-label.toString().length) + line.replace(/^[A-Z][0-9A-Z]{0,2},/, "").trimStart();
+    }
+
     const handleEditorKeyDown = (e: any) => {
         if (e.key === 'Tab') {
             e.preventDefault();
@@ -65,7 +75,14 @@ function App() {
             setExecuteReady(simulator.isRunning());
             setSimulatorState(simulator.state());
             setLogs(logger.logs());
+        } else if(e.key.toUpperCase() === 'F' && e.ctrlKey && e.shiftKey){
+            const editor = e.target;
+            const content = editor.value;
+
+            editor.value = content.split('\n').map(lineFormat).join('\n');
         }
+
+
     }
 
     return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,7 +40,7 @@ function App() {
     }
 
     const handleEditorKeyDown = (e: any) => {
-        if (e.key == 'Tab') {
+        if (e.key === 'Tab') {
             e.preventDefault();
             const editor = e.target;
             const content = editor.value;
@@ -48,7 +48,7 @@ function App() {
             const end = editor.selectionEnd;
             editor.value = content.substring(0, start) + "    " + content.substring(end);
             editor.selectionStart = editor.selectionEnd = start + 4;
-        } else if (e.key == 'Enter' && e.ctrlKey) {
+        } else if (e.key === 'Enter' && e.ctrlKey) {
             logger.clear();
 
             const result = and_then(parse(sourceCode), translate);

--- a/src/assembler/parse.ts
+++ b/src/assembler/parse.ts
@@ -135,7 +135,6 @@ const parse = (input: string): Result<TranslationUnit, Error> => {
                         if (!isHexadecimal(numeral)) return Err(Cause.InvalidHexadecimal, numeral);
                         pushStatement({ operation: Operation.HEX, numeral: hexadecimal });
                         break;
-                    break;
                     case "DEC":
                         if (!isDecimal(numeral)) return Err(Cause.InvalidDecimal, numeral);
                         pushStatement({ operation: Operation.DEC, numeral: decimal });

--- a/src/simulator/Simulator.ts
+++ b/src/simulator/Simulator.ts
@@ -432,7 +432,7 @@ export default class Simulator {
         this.logger.step("SC <- 0");
 
         this.writeMemory(this.registers.data);
-        if (this.registers.data = 0) this.registers.program++;
+        if (this.registers.data === 0) this.registers.program++;
         this.registers.time = 0;
     }
 }


### PR DESCRIPTION
Pressing Ctrl+Shift+F will reformat the instructions, is buggy at some edge cases.